### PR TITLE
Use SHA-1 really

### DIFF
--- a/libsignal-service-dotnet/util/Hash.cs
+++ b/libsignal-service-dotnet/util/Hash.cs
@@ -23,7 +23,7 @@ namespace libsignalservice.util
     {
         public static byte[] sha1(byte[] input)
         {
-            using (SHA512 sha = SHA512.Create())
+            using (SHA1 sha = SHA1.Create())
             {
                 return sha.ComputeHash(input);
             }


### PR DESCRIPTION
This has caused me quite some problems when working with your library ;-)

But thank you for porting libsignal-service to C#! Except for some minor issues it is working like a charm :+1: 