### PR TITLE
Internal certificate validation

### DIFF
--- a/libsignal-service-dotnet/SignalServiceMessageReceiver.cs
+++ b/libsignal-service-dotnet/SignalServiceMessageReceiver.cs
@@ -13,6 +13,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using static libsignalservice.messages.SignalServiceAttachment;
@@ -35,6 +36,7 @@ namespace libsignalservice
         private readonly string UserAgent;
         private readonly ConnectivityListener ConnectivityListener;
         private readonly CancellationToken Token;
+        private readonly X509Certificate2 server_cert;
 
         /// <summary>
         /// Construct a SignalServiceMessageReceiver.
@@ -44,12 +46,13 @@ namespace libsignalservice
         /// <param name="credentials">The Signal Service user's credentials</param>
         /// <param name="userAgent"></param>
         /// <param name="connectivityListener"></param>
-        public SignalServiceMessageReceiver(CancellationToken token, SignalServiceConfiguration urls, CredentialsProvider credentials, string userAgent, ConnectivityListener connectivityListener)
+        public SignalServiceMessageReceiver(CancellationToken token, SignalServiceConfiguration urls, CredentialsProvider credentials, string userAgent, ConnectivityListener connectivityListener, X509Certificate2 server_cert=null)
         {
             Token = token;
             Urls = urls;
             CredentialsProvider = credentials;
-            Socket = new PushServiceSocket(urls, credentials, userAgent);
+            this.server_cert = server_cert;
+            Socket = new PushServiceSocket(urls, credentials, userAgent, server_cert);
             UserAgent = userAgent;
             ConnectivityListener = connectivityListener;
         }
@@ -112,7 +115,7 @@ namespace libsignalservice
         /// <returns>A SignalServiceMessagePipe for receiving Signal Service messages.</returns>
         public SignalServiceMessagePipe CreateMessagePipe()
         {
-            SignalWebSocketConnection webSocket = new SignalWebSocketConnection(Token, Urls.SignalServiceUrls[0].Url, CredentialsProvider, UserAgent, ConnectivityListener);
+            SignalWebSocketConnection webSocket = new SignalWebSocketConnection(Token, Urls.SignalServiceUrls[0].Url, CredentialsProvider, UserAgent, ConnectivityListener, server_cert);
             return new SignalServiceMessagePipe(Token, webSocket, CredentialsProvider);
         }
 

--- a/libsignal-service-dotnet/SignalServiceMessageSender.cs
+++ b/libsignal-service-dotnet/SignalServiceMessageSender.cs
@@ -15,6 +15,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using static libsignalservice.messages.SignalServiceDataMessage;
 using static libsignalservice.push.DataMessage.Types.Quote.Types;
@@ -54,11 +55,11 @@ namespace libsignalservice
                                        string user, string password, int deviceId,
                                        SignalProtocolStore store,
                                        SignalServiceMessagePipe pipe,
-                                       IEventListener eventListener, string userAgent)
+                                       IEventListener eventListener, string userAgent, X509Certificate2 server_cert=null)
         {
             Token = token;
             CredentialsProvider = new StaticCredentialsProvider(user, password, null, deviceId);
-            this.socket = new PushServiceSocket(urls, CredentialsProvider, userAgent);
+            this.socket = new PushServiceSocket(urls, CredentialsProvider, userAgent, server_cert);
             this.store = store;
             this.localAddress = new SignalServiceAddress(user);
             this.pipe = pipe;

--- a/libsignal-service-dotnet/libsignal-service-dotnet.csproj
+++ b/libsignal-service-dotnet/libsignal-service-dotnet.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFrameworks>netstandard1.4;netcoreapp2.1;</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IncludeSource>True</IncludeSource>
     <IncludeSymbols>True</IncludeSymbols>

--- a/libsignal-service-dotnet/push/ProvisioningSocket.cs
+++ b/libsignal-service-dotnet/push/ProvisioningSocket.cs
@@ -3,6 +3,7 @@ using libsignalservice.crypto;
 using libsignalservice.push;
 using libsignalservice.websocket;
 using System.Collections.Concurrent;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -14,11 +15,11 @@ namespace libsignal.push
         private string WsUri;
         private readonly BlockingCollection<byte[]> IncomingRequests = new BlockingCollection<byte[]>(new ConcurrentQueue<byte[]>());
 
-        public ProvisioningSocket(string httpUri)
+        public ProvisioningSocket(string httpUri, X509Certificate2 server_cert=null)
         {
             WsUri = httpUri.Replace("https://", "wss://")
                 .Replace("http://", "ws://") + "/v1/websocket/provisioning/";
-            WebSocket = new WebSocketWrapper(WsUri);
+            WebSocket = new WebSocketWrapper(WsUri, server_cert);
             WebSocket.OnMessage(Connection_OnMessage);
         }
 

--- a/libsignal-service-dotnet/websocket/SignalWebSocketConnection.cs
+++ b/libsignal-service-dotnet/websocket/SignalWebSocketConnection.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
 using System.IO;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -28,7 +29,7 @@ namespace libsignalservice.websocket
         private readonly CancellationToken Token;
         private readonly ConnectivityListener Listener;
 
-        internal SignalWebSocketConnection(CancellationToken token, string httpUri, CredentialsProvider credentialsProvider, string userAgent, ConnectivityListener listener)
+        internal SignalWebSocketConnection(CancellationToken token, string httpUri, CredentialsProvider credentialsProvider, string userAgent, ConnectivityListener listener, X509Certificate2 server_cert)
         {
             Token = token;
             CredentialsProvider = credentialsProvider;
@@ -45,7 +46,7 @@ namespace libsignalservice.websocket
                     .Replace("http://", "ws://") + $"/v1/websocket/?login={credentialsProvider.User}.{credentialsProvider.DeviceId}&password={credentialsProvider.Password}";
             }
             UserAgent = userAgent;
-            WebSocket = new WebSocketWrapper(WsUri);
+            WebSocket = new WebSocketWrapper(WsUri, server_cert);
             WebSocket.OnConnect(Connection_OnOpened);
             WebSocket.OnMessage(Connection_OnMessage);
         }


### PR DESCRIPTION
So the patch mentioned in #9 does work, however it only works for sending (as receiving using the web socket that it doesn't touch).

I updated it to not blindly accept any certificate but require the one we care about.   I am not happy with a hardcoded string but figured we can use it as a placeholder while you decide a better option:

1. Have a static variable on PushServiceSocket that contains the hash or the x509 certificate that someone could set (or override if we wanted to provide a default) from a higher space.
2.  Just read the certificate from a file and hope it is there (like this the least)
3.  Make PushServiceSocket take the x509Certificate as part of the constructor and compute the hash from there

Personally I probably prefer 3.  Let me know and I can update the PR.  Still not a complete solution obviously.