### PR TITLE
Allow reading the total size of the two attachment stream types since.ToArray() is removed

### DIFF
--- a/libsignal-service-dotnet/crypto/AttachmentCipherInputStream.cs
+++ b/libsignal-service-dotnet/crypto/AttachmentCipherInputStream.cs
@@ -28,7 +28,7 @@ namespace libsignalservice.crypto
         public override bool CanRead => true;
         public override bool CanSeek => false;
         public override bool CanWrite => false;
-        public override long Length => throw new NotImplementedException();
+        public override long Length => TotalDataSize;
         public override long Position { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
         public static Stream CreateFor(Stream inputStream, long plaintextLength, byte[] combinedKeyMaterial, byte[] digest)

--- a/libsignal-service-dotnet/util/ContentLengthInputStream.cs
+++ b/libsignal-service-dotnet/util/ContentLengthInputStream.cs
@@ -9,17 +9,17 @@ namespace libsignalservice.util
     {
         private readonly Stream InputStream;
         private long BytesRemaining;
-
+        private readonly long TotalDataSize;
         public override bool CanRead => true;
         public override bool CanSeek => false;
         public override bool CanWrite => false;
-        public override long Length => throw new NotImplementedException();
+        public override long Length => TotalDataSize;
         public override long Position { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
         public ContentLengthInputStream(Stream inputStream, long contentLength)
         {
             InputStream = inputStream;
-            BytesRemaining = contentLength;
+            TotalDataSize=BytesRemaining = contentLength;
         }
 
         public override void Flush()


### PR DESCRIPTION
As ToArray is removed as an option on attachment streams the only way I saw to read them was knowing the total length to be able to make a Read call.  The only other option is to read in chunks until you don't read a full chunk.  Given the fact we know the length though I am not sure why this is not exposed (future planning?).