### PR TITLE
Fixed bug where we might confirm a message even though an exception is thrown

### DIFF
--- a/libsignal-service-dotnet/SignalServiceMessagePipe.cs
+++ b/libsignal-service-dotnet/SignalServiceMessagePipe.cs
@@ -61,19 +61,14 @@ namespace libsignalservice
             {
                 SignalServiceMessagePipeMessage message = new SignalServiceEnvelope(request.Body.ToByteArray(), CredentialsProvider.SignalingKey);
                 WebSocketResponseMessage response = CreateWebSocketResponse(request);
-                try
+                Logger.LogDebug("Calling callback with message {0}", request.Id);
+			    await callback.OnMessage(message);
+                if (!Token.IsCancellationRequested)
                 {
-                    Logger.LogDebug("Calling callback with message {0}", request.Id);
-                    await callback.OnMessage(message);
+                    Logger.LogDebug("Confirming message {0}", request.Id);
+                    Websocket.SendResponse(response);
                 }
-                finally
-                {
-                    if (!Token.IsCancellationRequested)
-                    {
-                        Logger.LogDebug("Confirming message {0}", request.Id);
-                        Websocket.SendResponse(response);
-                    }
-                }
+                
             }
             else if (IsPipeEmptyMessage(request))
             {


### PR DESCRIPTION
This might be a breaking change if this intentional originally.   This starts a race condition though where if an UE is thrown we try to confirm it before crashing out.   If something higher up in the stack trys to handle the exception and expected it to be confirmed for some odd reason this could be an issue (seems like an unlikely expected behavior for your windows client however).  just t/c removed.